### PR TITLE
Fix 0.6.1 release date

### DIFF
--- a/app/src/main/resources/io.github.hamza_algohary.Coulomb.metainfo.xml
+++ b/app/src/main/resources/io.github.hamza_algohary.Coulomb.metainfo.xml
@@ -58,7 +58,7 @@
 
     </description>
     <releases>
-        <release version="0.6.1" date="2024-2-6">
+        <release version="0.6.1" date="2025-2-6">
             <description>
                 <p> Updated icon. Fixed the app crashing when switching color scheme after opening about window. </p>
             </description>


### PR DESCRIPTION
The erroneous release date for 0.6.1 makes the app look unmaintained on Flathub - even though it is well maintained.